### PR TITLE
Add local-to-remote provisioning workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,73 +2,309 @@
 
 Demo assets and instructions to quickly get started with WebRTC using Amazon Kinesis Video Streams on Raspberry Pi devices.
 
-Requires an AWS account and a Raspberry Pi with a camera attached.
-
 ## What does this repo do?
 
-This repository contains mostly bash scripts that you can use to build the [Amazon Kinesis Video Streams for WebRTC SDK for C](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c). The scripts will perform the following tasks:
+This repository contains bash scripts that build the [Amazon Kinesis Video Streams for WebRTC SDK for C](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c) and provision the necessary AWS resources. The scripts will:
 
-* Installs the AWS CLI (used to help with initial AWS IoT Core provisioning)
-* Installs development and runtime dependencies for the SDK 
-* Patch some of the files in the SDK
-* Compiles the SDK and sample applications
-* Provision your Raspberry Pi as an AWS IoT Core Thing
-* Generates a "run" script for the SDK sample applications
-* Configures a systemctl service so the application can be managed via systemd services
+* Provision your device as an AWS IoT Core Thing (with certificates, policies, and role aliases)
+* Install development and runtime dependencies for the SDK on the Pi
+* Build libwebsockets from source (the SDK requires v4.3.5; Raspberry Pi OS Bookworm ships 4.1.6)
+* Compile the SDK with `BUILD_DEPENDENCIES=OFF` using system packages where possible
+* Generate a "run" script for the SDK sample applications
+* Configure a systemd service so the application runs automatically
 
-## Raspberry Pi Setup
+There are two ways to use this repo:
 
-To begin, setup your Raspberry Pi. You can follow these instructions if you do not know how to perform the necessary steps: https://projects.raspberrypi.org/en/projects/raspberry-pi-setting-up. The easiest way to get started is to use the Raspberry Pi Imager, which is available for download here: https://www.raspberrypi.com/software/
+1. **Local-to-Remote (recommended)** — Run provisioning from your laptop/desktop, deploy to the Pi over SSH
+2. **All-on-Pi (legacy)** — Run everything directly on the Raspberry Pi
 
-Once you have your Raspberry Pi device configured and connected to your network, follow these instructions to ensure that your camera is configured correctly: https://picamera.readthedocs.io/en/latest/quickstart.html.
+## Prerequisites
 
-Additionally, it is encouraged to update your Raspberry Pi and to verify that the git utility is installed prior to proceeding:
+Before using this repo, you need:
 
+1. **An AWS account** with permissions to create IoT and IAM resources (see [Minimum IAM permissions](#minimum-iam-permissions) below)
+2. **A Raspberry Pi** with:
+   - Raspberry Pi OS installed ([setup guide](https://projects.raspberrypi.org/en/projects/raspberry-pi-setting-up), [Raspberry Pi Imager](https://www.raspberrypi.com/software/))
+   - A camera module attached and enabled ([camera setup](https://picamera.readthedocs.io/en/latest/quickstart.html))
+   - Connected to a network reachable from your local machine
+   - SSH enabled with key-based authentication (e.g. `ssh pi@192.168.1.100`)
+   - Updated packages and git installed:
+     ```bash
+     sudo apt update && sudo apt install git -y
+     ```
+3. **On your local machine** (laptop/desktop):
+   - [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+   - `jq` (`brew install jq` on macOS, `apt install jq` on Linux)
+   - SSH key-based access to the Pi
+
+## Minimum IAM permissions
+
+The provisioning scripts do not require administrator access. A minimal IAM policy is provided in [`iot/provisioning-iam-policy.json`](iot/provisioning-iam-policy.json). Before using it, replace `<ACCOUNT_ID>` with your AWS account ID.
+
+The policy grants permissions for:
+
+| Service | Actions | Purpose |
+|---|---|---|
+| IoT | CreateThing, CreateThingType, DescribeThing, DescribeThingType | Register the Pi as an IoT Thing |
+| IoT | CreateKeysAndCertificate, AttachPolicy, AttachThingPrincipal | Create and attach device certificates |
+| IoT | CreatePolicy, GetPolicy, CreateRoleAlias, DescribeRoleAlias, DescribeEndpoint | Set up IoT credential provider |
+| IAM | CreateRole, GetRole, PutRolePolicy, GetRolePolicy, PassRole | Create the role that IoT assumes for KVS access |
+| STS | GetCallerIdentity | Verify the active AWS session |
+
+You can create this policy in the AWS Console under IAM > Policies > Create Policy (JSON tab), or via the CLI:
+
+```bash
+aws iam create-policy \
+  --policy-name KVSWebRTCProvisioningPolicy \
+  --policy-document file://iot/provisioning-iam-policy.json
 ```
-sudo apt update
-sudo apt install git -y
+
+Then attach it to your IAM user, group, or SSO permission set.
+
+---
+
+## Option 1: Local-to-Remote Setup (Recommended)
+
+This approach runs AWS provisioning from your local machine using AWS SSO (or any configured credentials), then deploys everything to the Pi over SSH. No AWS credentials are ever stored on the Pi.
+
+### Step 1: Clone this repo (on your local machine)
+
+```bash
+git clone https://github.com/dave-malone/aws-kvs-webrtc-demo-for-raspberry-pi
+cd aws-kvs-webrtc-demo-for-raspberry-pi
 ```
 
-## Obtain AWS credentials
+### Step 2: Configure AWS credentials
 
-The scripts in this project make use of the AWS CLI in order to provision resources into your AWS account. To use these scripts, create a temporary AWS key pair and set these as environment variables on your Pi. These will only be used to provision your initial set of AWS Cloud resources and can be discarded after the subsequent steps have successfully completed. Follow these instructions to create an AWS access key: https://repost.aws/knowledge-center/create-access-key.
+If you use AWS IAM Identity Center (SSO), run the setup helper:
 
-Then, set your AWS access key as environment variables in your Raspberry Pi device:
-
+```bash
+./setup-aws-sso.sh myprofile
 ```
-export AWS_ACCESS_KEY_ID= <AWS account access key>
-export AWS_SECRET_ACCESS_KEY= <AWS account secret key>
+
+This walks you through `aws configure sso` interactively. You'll need your Identity Center start URL, account ID, and role name.
+
+If you already have a working AWS CLI profile (SSO, IAM user, or otherwise), skip this step.
+
+### Step 3: Log in
+
+```bash
+aws sso login --profile myprofile
+```
+
+### Step 4: Provision and deploy
+
+```bash
+./provision-local.sh \
+  --profile myprofile \
+  --pi-host pi@192.168.1.100 \
+  --thing-name MyCameraDevice
+```
+
+This single command will:
+1. Verify prerequisites (AWS CLI v2, jq, ssh, scp, curl) and AWS session
+2. Create the IoT Thing, IAM role, IoT policies, and device certificates locally
+3. SCP the certificates and configuration to the Pi
+4. SSH into the Pi to install dependencies, build libwebsockets and the SDK, and start the systemd service
+
+### Step 5: Verify
+
+```bash
+ssh pi@192.168.1.100 'sudo systemctl status kvs-webrtc.service'
+```
+
+---
+
+## Option 2: All-on-Pi Setup (Legacy)
+
+This approach runs everything directly on the Raspberry Pi. It requires temporary AWS access keys on the device.
+
+### Obtain AWS credentials
+
+Create a temporary AWS access key pair ([instructions](https://repost.aws/knowledge-center/create-access-key)) and set them on your Pi:
+
+```bash
+export AWS_ACCESS_KEY_ID=<your-access-key>
+export AWS_SECRET_ACCESS_KEY=<your-secret-key>
 export AWS_DEFAULT_REGION=us-east-1
 ```
 
-## Using this repostiory to provision your Raspberry Pi for use with Amazon Kinesis Video Streams for WebRTC
+### Clone and run
 
-Clone this repo:
-
-`git clone --recurse-submodules https://github.com/dave-malone/aws-kvs-webrtc-demo-for-raspberry-pi`
-
-Run the easy install script. Please note that this script will install packages on your Raspberry Pi, will clone and build the amazon-kinesis-video-streams-webrtc-sdk-c, and will also provision AWS Cloud resources on your behalf. Installing packages and building the webrtc sdk will take some time, so please be patient.
-
-The `easy_install` script can be passed the AWS IoT Core Thing Name as an argument. If you do not set this, the script will prompt and wait for you to enter a Thing Name before proceeding. 
-
-```
+```bash
+git clone --recurse-submodules https://github.com/dave-malone/aws-kvs-webrtc-demo-for-raspberry-pi
 cd aws-kvs-webrtc-demo-for-raspberry-pi
 ./easy_install.sh YOUR_THING_NAME
 ```
 
-Upon successful completion, a new service named `kvs-webrtc.service` will be registered. You can check the status of this service by running the following command: 
-`sudo systemctl status kvs-webrtc.service`. 
+**Important:** Delete the temporary AWS access key pair after setup completes.
 
-The sample applications have been installed under `/opt/amazon-kinesis-video-streams-webrtc-sdk-c`. The service will direct Stdout and Stderror logs to `/var/log/kvs-webrtc.log`, and service specific logs are in the usual `tail -f /var/log/syslog` file.
+---
 
-Once the demo program is working, you can login to your AWS Console, navigate to Kinesis Video Streams > Signaling channels, and click the link for the signaling channel with the same name you provided to your IoT Thing during the `easy_install` process. This will allow you to view your camera's live feed in the browser to verify that everything is working as expected.
+## Test your camera
 
-## Test your camera device
+Once the service is running, navigate to the [KVS WebRTC Test Page](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html), enter your AWS region, credentials, and device name, then click "Start Viewer" to see a live feed.
 
-As long as your Raspberry Pi shows that the service is successfully running (see steps above), you can navigate to the KVS WebRTC Test Page, enter in your AWS region, AWS credentials, and the name of your device used in the previous steps, and click the "Start Viewer" button. If everything is working, you will be able to view a live feed from your camera!
+## Service management
 
-https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html
+```bash
+# Check status
+sudo systemctl status kvs-webrtc.service
 
-## Clean up 
+# View logs
+tail -f /var/log/kvs-webrtc.log
 
-Ensure that you have deleted the AWS access key pair used to initially provision your Raspberry Pi device, as it is no longer needed. 
+# Restart
+sudo systemctl restart kvs-webrtc.service
+```
+
+## Clean up
+
+To remove the KVS WebRTC installation from the Pi:
+
+```bash
+# Run on the Pi (or via SSH)
+sudo systemctl stop kvs-webrtc.service
+sudo systemctl disable kvs-webrtc.service
+sudo rm /etc/systemd/system/kvs-webrtc.service
+sudo systemctl daemon-reload
+sudo rm -rf /opt/amazon-kinesis-video-streams-webrtc-sdk-c
+```
+
+If using the legacy approach, ensure you have deleted the temporary AWS access key pair.
+
+---
+
+## Customizing the GStreamer pipeline
+
+The SDK samples use a GStreamer pipeline to capture video from the camera and encode it for WebRTC streaming. By default, the setup scripts patch the SDK to read the pipeline from environment variables, so you can change resolution, framerate, encoder settings, or even the camera source without recompiling.
+
+Two environment variables are supported:
+
+| Variable | Used when | Required appsink names |
+|---|---|---|
+| `KVS_GST_VIDEO_PIPELINE` | Video-only streaming | `appsink-video` |
+| `KVS_GST_AUDIO_VIDEO_PIPELINE` | Audio+video streaming | `appsink-video` and `appsink-audio` |
+
+If the variable is not set or empty, the SDK falls back to its built-in default pipeline.
+
+The pipeline is configured in the run script at `/opt/amazon-kinesis-video-streams-webrtc-sdk-c/run-kvs-webrtc-client-master-sample.sh`. Edit the `KVS_GST_VIDEO_PIPELINE` line and restart the service:
+
+```bash
+sudo nano /opt/amazon-kinesis-video-streams-webrtc-sdk-c/run-kvs-webrtc-client-master-sample.sh
+sudo systemctl restart kvs-webrtc.service
+```
+
+### Default pipeline (Raspberry Pi with libcamera)
+
+```
+libcamerasrc ! video/x-raw,width=1280,height=720,framerate=30/1 !
+  queue ! videoconvert ! video/x-raw,format=I420 !
+  x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE
+    tune=zerolatency key-int-max=30 !
+  video/x-h264,stream-format=byte-stream,alignment=au !
+  appsink sync=TRUE emit-signals=TRUE name=appsink-video
+```
+
+### Example: lower resolution for reduced CPU usage
+
+```
+libcamerasrc ! video/x-raw,width=640,height=480,framerate=15/1 !
+  queue ! videoconvert ! video/x-raw,format=I420 !
+  x264enc bframes=0 speed-preset=ultrafast bitrate=256 byte-stream=TRUE
+    tune=zerolatency key-int-max=15 !
+  video/x-h264,stream-format=byte-stream,alignment=au !
+  appsink sync=TRUE emit-signals=TRUE name=appsink-video
+```
+
+### Example: test pattern (no camera needed)
+
+```
+videotestsrc is-live=TRUE pattern=ball !
+  video/x-raw,width=1280,height=720,framerate=30/1 !
+  queue ! videoconvert ! video/x-raw,format=I420 !
+  x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE
+    tune=zerolatency key-int-max=30 !
+  video/x-h264,stream-format=byte-stream,alignment=au !
+  appsink sync=TRUE emit-signals=TRUE name=appsink-video
+```
+
+### Tips
+
+- Use `gst-launch-1.0 <your pipeline elements> ! fakesink` to test a pipeline before putting it in the run script
+- The pipeline must be a single string on one line in the run script (no line breaks)
+- The `appsink` element names (`appsink-video`, `appsink-audio`) must match exactly — the SDK uses these names to pull frames
+
+---
+
+## Tested configurations
+
+| Raspberry Pi Model | OS | Architecture | Kernel | Status |
+|---|---|---|---|---|
+| Raspberry Pi 4 Model B | Raspbian Bookworm (12) | armhf (32-bit userspace) | 6.12 aarch64 | Tested, working |
+| Raspberry Pi 4 Model B | Raspberry Pi OS Bookworm (12) | arm64 (64-bit) | — | Untested, may have issues |
+| Raspberry Pi 5 | — | — | — | Untested |
+| Raspberry Pi 3 / Zero 2 W | — | — | — | Untested |
+
+**Notes:**
+- The 32-bit (armhf) Raspbian image is the tested configuration. The 64-bit (arm64) Raspberry Pi OS image may have different package names or library paths — if you test it, please report your results.
+- Older OS versions (Bullseye and earlier) use the legacy camera stack (`raspistill`, `v4l2`) instead of `libcamera`. The GStreamer pipeline patch in `setup-pi.sh` targets Bookworm's `libcamerasrc` and will not work on Bullseye without modification.
+
+---
+
+## Troubleshooting
+
+### Wi-Fi not connecting after flashing with Raspberry Pi Imager
+
+On recent Bookworm images, the Wi-Fi configuration set through Raspberry Pi Imager (or `raspi-config`) may not apply correctly. NetworkManager has replaced `wpa_supplicant` as the default network manager, and the old configuration methods don't always work.
+
+**Workaround:** Connect a monitor, keyboard, and mouse to the Pi, then use `nmtui` to configure Wi-Fi:
+
+```bash
+sudo nmtui
+```
+
+Select "Activate a connection", choose your Wi-Fi network, and enter the password. Once connected, you can find the Pi's IP address with `hostname -I` and switch to SSH for the remaining setup.
+
+### No camera detected
+
+If `setup-pi.sh` reports "No camera detected by libcamera":
+
+1. **Check the ribbon cable** — ensure it's firmly seated at both the camera module and the Pi's CSI port, with the contacts facing the correct direction
+2. **Verify boot config** — check that `camera_auto_detect=1` is present in `/boot/firmware/config.txt` (or `/boot/config.txt` on older images)
+3. **Reboot** after any config changes: `sudo reboot`
+4. **Test manually:**
+   ```bash
+   rpicam-hello --list-cameras
+   ```
+   You should see at least one camera listed with its supported modes.
+
+### Peer connection established but no video
+
+If the KVS WebRTC test page shows a peer connection but no video feed:
+
+- Check the application logs for GStreamer errors:
+  ```bash
+  grep -i 'error\|pipeline\|gstreamer' /var/log/kvs-webrtc.log | tail -20
+  ```
+- Look for kernel errors related to the camera:
+  ```bash
+  dmesg | grep -i 'unicam\|camera\|csi' | tail -10
+  ```
+- A common cause is the `Wrong width or height` error in `dmesg`, which means the GStreamer pipeline is trying to open the camera at a resolution the sensor doesn't natively support. This is fixed by the `libcamerasrc` patch in `setup-pi.sh`. If you see this error, rebuild the SDK:
+  ```bash
+  rm -rf ~/kvs-webrtc-setup/amazon-kinesis-video-streams-webrtc-sdk-c/build
+  ~/kvs-webrtc-setup/setup-pi.sh
+  ```
+
+### Service fails to start
+
+```bash
+sudo systemctl status kvs-webrtc.service
+journalctl -u kvs-webrtc.service --no-pager -n 50
+```
+
+Common causes:
+- **Missing IoT certificates** — verify files exist under `/opt/amazon-kinesis-video-streams-webrtc-sdk-c/iot/certs/`
+- **Wrong region** — check that `AWS_DEFAULT_REGION` in the run script matches where your IoT resources were provisioned
+- **Clock skew** — TLS connections will fail if the Pi's clock is significantly off. Install and enable NTP: `sudo apt install ntp`

--- a/SDK_BUILD_NOTES.md
+++ b/SDK_BUILD_NOTES.md
@@ -1,0 +1,113 @@
+# KVS WebRTC SDK — Build and Patching Notes for Raspberry Pi
+
+These notes document the changes required to build and run the [amazon-kinesis-video-streams-webrtc-sdk-c](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c) on Raspberry Pi OS Bookworm (Debian 12) with `BUILD_DEPENDENCIES=OFF`. This is intended for the SDK engineering team as a summary of issues encountered and workarounds applied.
+
+## 1. Using BUILD_DEPENDENCIES=OFF
+
+Building with `-DBUILD_DEPENDENCIES=OFF` skips the SDK's bundled dependency builds (libsrtp, libusrsctp, libwebsockets) and relies on system-installed packages instead. This significantly reduces compile time on low-powered devices like the Raspberry Pi.
+
+### Dependency compatibility (Raspberry Pi OS Bookworm armhf)
+
+| Dependency | SDK pins | Bookworm provides | Compatible? | Notes |
+|---|---|---|---|---|
+| libsrtp | `bd0f27ec` (post-v2.5.0) | 2.5.0-3 (`libsrtp2-dev`) | Yes | Minor commit delta, ABI compatible |
+| libusrsctp | `1ade45cb` | 0.9.5.0-2 (`libusrsctp-dev`) | Yes | Works at runtime |
+| libwebsockets | **v4.3.5** | **4.1.6-3** (`libwebsockets-dev`) | **No** | API changes between 4.1 and 4.3 |
+| kvsCommonLws | v1.6.1 | N/A | N/A | Always built from source (outside `if(BUILD_DEPENDENCIES)` block) |
+| OpenSSL | — | 3.0.15 (`libssl-dev`) | Yes | Already excluded from bundled build upstream |
+| mbedTLS | — | 2.28.3 (`libmbedtls-dev`) | Yes | Already excluded from bundled build upstream |
+
+### The libwebsockets gap
+
+The SDK requires libwebsockets v4.3.5 but Bookworm ships 4.1.6. This is the only dependency that prevents a clean `BUILD_DEPENDENCIES=OFF` build with stock packages. The workaround is to build libwebsockets v4.3.5 from source and install it to `/usr/local` before building the SDK:
+
+```bash
+git clone --branch v4.3.5 --depth 1 https://github.com/warmcat/libwebsockets.git
+cd libwebsockets && mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release \
+  -DLWS_WITH_STATIC=ON -DLWS_WITH_SHARED=ON \
+  -DLWS_WITHOUT_TESTAPPS=ON -DLWS_WITHOUT_TEST_SERVER=ON \
+  -DLWS_WITHOUT_TEST_PING=ON -DLWS_WITHOUT_TEST_CLIENT=ON
+make -j$(nproc) && sudo make install && sudo ldconfig
+```
+
+Then build the SDK:
+
+```bash
+cmake .. -DBUILD_DEPENDENCIES=OFF -DIOT_CORE_ENABLE_CREDENTIALS=ON -DCMAKE_PREFIX_PATH=/usr/local
+make -j$(nproc)
+```
+
+### Suggestion for the SDK
+
+Consider adding a `BUILD_LIBWEBSOCKETS` option (defaulting to ON) that can be toggled independently of `BUILD_DEPENDENCIES`, similar to how OpenSSL and mbedTLS are already handled. This would allow users on platforms with compatible libsrtp/libusrsctp packages to skip those builds while still building libwebsockets from source when the system version is too old.
+
+## 2. GStreamer pipeline issues on Bookworm
+
+### Problem: `autovideosrc` does not work with libcamera
+
+Raspberry Pi OS Bookworm replaced the legacy camera stack with `libcamera`. The SDK samples hardcode `autovideosrc` for the `DEVICE_SOURCE` pipeline, which resolves to `v4l2src`. On Bookworm, `v4l2src` opens the unicam device directly and attempts to capture at 1280x720, but the CSI sensor only exposes its native resolution (e.g. 4056x3040 for the IMX477). This produces a kernel error:
+
+```
+unicam fe801000.csi: Wrong width or height 1280x720 (remote pad set to 4056x3040)
+unicam fe801000.csi: Failed to start media pipeline: -22
+```
+
+The fix is to use `libcamerasrc` (from the `gstreamer1.0-libcamera` package), which routes through the ISP and handles resolution scaling.
+
+### Problem: hardcoded pipelines require recompilation to change
+
+The `DEVICE_SOURCE` pipelines in `GstMedia.c` are hardcoded strings. Any change to resolution, framerate, encoder settings, or source element requires recompiling the SDK. This is particularly painful on a Raspberry Pi where compilation takes several minutes.
+
+### Problem: profile mismatch causes grey video
+
+The hardcoded pipeline specifies `profile=baseline` in the output caps filter after `x264enc`, but `x264enc` with default settings produces `high` profile H.264. The caps filter silently drops frames that don't match, resulting in a viewer that receives the first keyframe (which may pass negotiation) but then shows grey for all subsequent frames.
+
+### Our workaround: environment variable override
+
+We patched `GstMedia.c` so that the `DEVICE_SOURCE` case checks an environment variable before falling back to the hardcoded pipeline:
+
+- `KVS_GST_VIDEO_PIPELINE` — for `SAMPLE_STREAMING_VIDEO_ONLY`
+- `KVS_GST_AUDIO_VIDEO_PIPELINE` — for `SAMPLE_STREAMING_AUDIO_VIDEO`
+
+The patch adds `#include <stdlib.h>` and wraps each `DEVICE_SOURCE` block:
+
+```c
+case DEVICE_SOURCE: {
+    {
+        const char* envPipeline = getenv("KVS_GST_VIDEO_PIPELINE");
+        if (envPipeline != NULL && envPipeline[0] != '\0') {
+            DLOGI("[KVS GStreamer Master] Using custom pipeline from KVS_GST_VIDEO_PIPELINE");
+            senderPipeline = gst_parse_launch(envPipeline, &gError);
+        } else {
+            // original hardcoded pipeline
+            senderPipeline = gst_parse_launch("autovideosrc ...", &gError);
+        }
+    }
+    break;
+}
+```
+
+The working pipeline for Raspberry Pi with libcamera:
+
+```
+libcamerasrc ! video/x-raw,width=1280,height=720,framerate=30/1 !
+queue ! videoconvert ! video/x-raw,format=I420 !
+x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE
+  tune=zerolatency key-int-max=30 !
+video/x-h264,stream-format=byte-stream,alignment=au !
+appsink sync=TRUE emit-signals=TRUE name=appsink-video
+```
+
+Key differences from the SDK default:
+- `libcamerasrc` instead of `autovideosrc`
+- Explicit `format=I420` caps before x264enc (required for correct color encoding)
+- `key-int-max=30` for frequent keyframes (one per second at 30fps)
+- No `profile=baseline` constraint in output caps (avoids frame dropping)
+
+### Suggestions for the SDK
+
+1. **Add env var support upstream** — the `KVS_GST_VIDEO_PIPELINE` / `KVS_GST_AUDIO_VIDEO_PIPELINE` pattern is minimal and backward-compatible. If the env var isn't set, behavior is unchanged.
+2. **Remove `profile=baseline` from output caps** — or set `profile` as an x264enc property instead of a downstream caps filter. The current approach silently drops frames when x264enc produces a different profile.
+3. **Add `key-int-max`** — the default x264enc keyframe interval is 250 frames (~10 seconds at 25fps). WebRTC viewers that join mid-stream won't see video until the next keyframe. A 1-2 second interval is more appropriate for real-time streaming.
+4. **Document libcamera support** — Raspberry Pi OS Bookworm is the current stable release and uses libcamera exclusively. The SDK samples should document this or detect the platform.

--- a/build-kvs-webrtc.sh
+++ b/build-kvs-webrtc.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+#
+# build-kvs-webrtc.sh
+#
+# Installs build/runtime dependencies and compiles the KVS WebRTC SDK.
+# Uses BUILD_DEPENDENCIES=OFF with system packages for libsrtp and
+# libusrsctp. Builds libwebsockets v4.3.5 from source since the SDK
+# requires it and Bookworm only ships 4.1.6.
+#
+
+set -euo pipefail
+
+LWS_VERSION="v4.3.5"
 
 echo "installing amazon-kinesis-video-streams-webrtc-sdk-c build dependencies"
 sudo apt-get install -y \
@@ -6,6 +18,8 @@ sudo apt-get install -y \
   libmbedtls-dev \
   libcurl4-openssl-dev \
   liblog4cplus-dev \
+  libsrtp2-dev \
+  libusrsctp-dev \
   libgstreamer1.0-dev \
   libgstreamer-plugins-base1.0-dev \
   gstreamer1.0-plugins-base-apps \
@@ -14,18 +28,52 @@ sudo apt-get install -y \
   gstreamer1.0-plugins-ugly \
   gstreamer1.0-tools
 
-# patch CMakeLists.txt; don't build openssl or mbedtls since those are installed via package manager
-sed -i 's+build_dependency(openssl ${BUILD_ARGS})+#build_dependency(openssl ${BUILD_ARGS})+g' amazon-kinesis-video-streams-webrtc-sdk-c/CMakeLists.txt
-sed -i 's+set(OPENSSL_ROOT_DIR ${OPEN_SRC_INSTALL_PREFIX})+#set(OPENSSL_ROOT_DIR ${OPEN_SRC_INSTALL_PREFIX})+g' amazon-kinesis-video-streams-webrtc-sdk-c/CMakeLists.txt
-sed -i 's+build_dependency(mbedtls ${BUILD_ARGS})+#build_dependency(mbedtls ${BUILD_ARGS})+g' amazon-kinesis-video-streams-webrtc-sdk-c/CMakeLists.txt
+# Build libwebsockets from source (SDK requires v4.3.5, Bookworm has 4.1.6)
+LWS_MARKER="/usr/local/lib/pkgconfig/libwebsockets.pc"
+if [[ -f "${LWS_MARKER}" ]] && pkg-config --atleast-version=4.3.5 libwebsockets 2>/dev/null; then
+  echo "libwebsockets >= 4.3.5 already installed, skipping"
+else
+  echo "building libwebsockets ${LWS_VERSION} from source"
+  LWS_SRC_DIR="$(pwd)/libwebsockets"
 
-# patch samples/Samples.h to enable IoT Core Credentials Provider
-sed -i 's+//#define IOT_CORE_ENABLE_CREDENTIALS  1+#define IOT_CORE_ENABLE_CREDENTIALS  1+g' amazon-kinesis-video-streams-webrtc-sdk-c/samples/Samples.h
+  if [[ ! -d "${LWS_SRC_DIR}" ]]; then
+    git clone --branch "${LWS_VERSION}" --depth 1 \
+      https://github.com/warmcat/libwebsockets.git "${LWS_SRC_DIR}"
+  fi
+
+  mkdir -p "${LWS_SRC_DIR}/build"
+  cd "${LWS_SRC_DIR}/build"
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLWS_WITH_STATIC=ON \
+    -DLWS_WITH_SHARED=ON \
+    -DLWS_WITHOUT_TESTAPPS=ON \
+    -DLWS_WITHOUT_TEST_SERVER=ON \
+    -DLWS_WITHOUT_TEST_PING=ON \
+    -DLWS_WITHOUT_TEST_CLIENT=ON
+  make -j$(nproc)
+  sudo make install
+  sudo ldconfig
+  cd ../..
+fi
+
+# Enable IoT Core Credentials Provider in samples.
+# Newer SDK versions use a CMake flag; older versions use a #define in Samples.h.
+SAMPLES_H=amazon-kinesis-video-streams-webrtc-sdk-c/samples/Samples.h
+if [ ! -f "$SAMPLES_H" ]; then
+  SAMPLES_H=amazon-kinesis-video-streams-webrtc-sdk-c/samples/common/Samples.h
+fi
+if [ -f "$SAMPLES_H" ]; then
+  sed -i 's+//#define IOT_CORE_ENABLE_CREDENTIALS  1+#define IOT_CORE_ENABLE_CREDENTIALS  1+g' "$SAMPLES_H"
+fi
 
 mkdir -p amazon-kinesis-video-streams-webrtc-sdk-c/build
 cd amazon-kinesis-video-streams-webrtc-sdk-c/build
 
-cmake ..
-make
+cmake .. \
+  -DBUILD_DEPENDENCIES=OFF \
+  -DIOT_CORE_ENABLE_CREDENTIALS=ON \
+  -DCMAKE_PREFIX_PATH=/usr/local
+make -j$(nproc)
 
 cd ../..

--- a/iot/provisioning-iam-policy.json
+++ b/iot/provisioning-iam-policy.json
@@ -1,0 +1,58 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "IoTThingProvisioning",
+      "Effect": "Allow",
+      "Action": [
+        "iot:CreateThing",
+        "iot:CreateThingType",
+        "iot:DescribeThing",
+        "iot:DescribeThingType"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IoTCertificateManagement",
+      "Effect": "Allow",
+      "Action": [
+        "iot:CreateKeysAndCertificate",
+        "iot:AttachPolicy",
+        "iot:AttachThingPrincipal"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IoTPolicyAndRoleAlias",
+      "Effect": "Allow",
+      "Action": [
+        "iot:CreatePolicy",
+        "iot:GetPolicy",
+        "iot:CreateRoleAlias",
+        "iot:DescribeRoleAlias",
+        "iot:DescribeEndpoint"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IAMRoleForIoT",
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateRole",
+        "iam:GetRole",
+        "iam:PutRolePolicy",
+        "iam:GetRolePolicy",
+        "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::<ACCOUNT_ID>:role/KVSCameraCertificateBasedIAMRole"
+    },
+    {
+      "Sid": "VerifyIdentity",
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetCallerIdentity"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/patch-gst-pipeline.sh
+++ b/patch-gst-pipeline.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# patch-gst-pipeline.sh
+#
+# Patches the KVS WebRTC SDK's GstMedia.c so that DEVICE_SOURCE pipelines
+# check environment variables before falling back to the hardcoded defaults:
+#
+#   KVS_GST_VIDEO_PIPELINE       - video-only pipeline
+#   KVS_GST_AUDIO_VIDEO_PIPELINE - audio+video pipeline
+#
+# The pipeline string MUST contain the expected appsink element names:
+#   appsink-video (and appsink-audio for audio+video)
+#
+# Usage:
+#   ./patch-gst-pipeline.sh /path/to/samples/common/GstMedia.c
+#
+
+set -euo pipefail
+
+GSTMEDIA="${1:?Usage: $0 <path-to-GstMedia.c>}"
+
+if [[ ! -f "${GSTMEDIA}" ]]; then
+  echo "Error: ${GSTMEDIA} not found"
+  exit 1
+fi
+
+if grep -q 'KVS_GST_VIDEO_PIPELINE' "${GSTMEDIA}"; then
+  echo "GstMedia.c is already patched, skipping."
+  exit 0
+fi
+
+# Add stdlib.h for getenv() if not already present
+if ! grep -q '#include <stdlib.h>' "${GSTMEDIA}"; then
+  sed -i '/#include "Samples.h"/a #include <stdlib.h>' "${GSTMEDIA}"
+  echo "Added #include <stdlib.h>"
+fi
+
+# Use awk to wrap each DEVICE_SOURCE gst_parse_launch block with an env var check.
+# We track which streaming section we're in (VIDEO_ONLY vs AUDIO_VIDEO) to pick
+# the right env var name.
+awk '
+BEGIN {
+  section = ""
+  in_device_source = 0
+  collecting = 0
+  block = ""
+}
+
+/case SAMPLE_STREAMING_VIDEO_ONLY:/ { section = "video" }
+/case SAMPLE_STREAMING_AUDIO_VIDEO:/ { section = "audio_video" }
+
+# Detect start of a DEVICE_SOURCE case block
+/case DEVICE_SOURCE: \{/ {
+  if (section == "video" || section == "audio_video") {
+    in_device_source = 1
+  }
+  print
+  next
+}
+
+# Inside DEVICE_SOURCE, look for the gst_parse_launch call
+in_device_source && /senderPipeline = gst_parse_launch\(/ && !collecting {
+  collecting = 1
+  block = $0 "\n"
+  next
+}
+
+# Continue collecting lines of the gst_parse_launch call until we see break;
+collecting && !/break;/ {
+  block = block $0 "\n"
+  next
+}
+
+# We hit break; — emit the wrapped block
+collecting && /break;/ {
+  collecting = 0
+  in_device_source = 0
+
+  if (section == "video") {
+    envvar = "KVS_GST_VIDEO_PIPELINE"
+  } else {
+    envvar = "KVS_GST_AUDIO_VIDEO_PIPELINE"
+  }
+
+  printf "                    {\n"
+  printf "                        const char* envPipeline = getenv(\"%s\");\n", envvar
+  printf "                        if (envPipeline != NULL && envPipeline[0] != '"'"'\\0'"'"') {\n"
+  printf "                            DLOGI(\"[KVS GStreamer Master] Using custom pipeline from %s\");\n", envvar
+  printf "                            senderPipeline = gst_parse_launch(envPipeline, &gError);\n"
+  printf "                        } else {\n"
+  # Re-indent the original block by 4 spaces
+  n = split(block, lines, "\n")
+  for (i = 1; i <= n; i++) {
+    if (lines[i] != "") {
+      printf "    %s\n", lines[i]
+    }
+  }
+  printf "                        }\n"
+  printf "                    }\n"
+  print
+  next
+}
+
+{ print }
+' "${GSTMEDIA}" > "${GSTMEDIA}.patched"
+
+mv "${GSTMEDIA}.patched" "${GSTMEDIA}"
+
+# Verify the patch was applied
+if grep -q 'KVS_GST_VIDEO_PIPELINE' "${GSTMEDIA}" && grep -q 'KVS_GST_AUDIO_VIDEO_PIPELINE' "${GSTMEDIA}"; then
+  echo "Patched GstMedia.c: DEVICE_SOURCE blocks now check KVS_GST_VIDEO_PIPELINE / KVS_GST_AUDIO_VIDEO_PIPELINE"
+else
+  echo "WARNING: Patch may not have applied correctly. Check GstMedia.c manually."
+  exit 1
+fi

--- a/provision-local.sh
+++ b/provision-local.sh
@@ -1,0 +1,361 @@
+#!/bin/bash
+#
+# provision-local.sh
+#
+# Runs from your local machine (laptop/desktop). Provisions AWS IoT resources
+# using your local AWS credentials (SSO or otherwise), then deploys certs and
+# the SDK build to a Raspberry Pi over SSH.
+#
+# Usage:
+#   ./provision-local.sh --profile <aws-profile> --pi-host <user@host> --thing-name <name>
+#
+# Prerequisites:
+#   - AWS CLI v2 installed locally
+#   - An active AWS session (e.g. `aws sso login --profile <profile>`)
+#   - SSH key-based access to the Raspberry Pi
+#
+
+set -euo pipefail
+
+# ─── Prerequisites check ─────────────────────────────────────────────────────
+
+MISSING=()
+for cmd in aws jq ssh scp curl; do
+  if ! command -v "$cmd" &>/dev/null; then
+    MISSING+=("$cmd")
+  fi
+done
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "Error: The following required tools are not installed: ${MISSING[*]}"
+  echo ""
+  echo "Install them before running this script:"
+  echo "  macOS:  brew install ${MISSING[*]}"
+  echo "  Linux:  sudo apt-get install -y ${MISSING[*]}"
+  exit 1
+fi
+
+# Verify AWS CLI is v2 (needed for SSO support)
+AWS_CLI_MAJOR=$(aws --version 2>&1 | grep -oE 'aws-cli/[0-9]+' | cut -d/ -f2)
+if [[ "${AWS_CLI_MAJOR}" -lt 2 ]]; then
+  echo "Error: AWS CLI v2 is required (found v${AWS_CLI_MAJOR})."
+  echo "Install it from: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+  exit 1
+fi
+
+# ─── Defaults ────────────────────────────────────────────────────────────────
+
+AWS_PROFILE=""
+PI_HOST=""
+THING_NAME=""
+AWS_REGION=""
+KVS_INSTALL_DIR="/opt/amazon-kinesis-video-streams-webrtc-sdk-c"
+
+# ─── Parse arguments ─────────────────────────────────────────────────────────
+
+usage() {
+  cat <<EOF
+Usage: $0 [OPTIONS]
+
+Options:
+  --profile PROFILE     AWS CLI profile name (required)
+  --pi-host HOST        SSH target for the Pi, e.g. pi@192.168.1.100 (required)
+  --thing-name NAME     AWS IoT Thing name for this device (prompted if omitted)
+  --region REGION       AWS region (defaults to profile region, then us-east-1)
+  -h, --help            Show this help message
+
+Example:
+  $0 --profile work --pi-host pi@192.168.1.100 --thing-name MyCamera
+EOF
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --profile)    AWS_PROFILE="$2"; shift 2 ;;
+    --pi-host)    PI_HOST="$2"; shift 2 ;;
+    --thing-name) THING_NAME="$2"; shift 2 ;;
+    --region)     AWS_REGION="$2"; shift 2 ;;
+    -h|--help)    usage ;;
+    *)            echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+# ─── Validate inputs ─────────────────────────────────────────────────────────
+
+if [[ -z "$AWS_PROFILE" ]]; then
+  echo "Error: --profile is required"
+  usage
+fi
+
+if [[ -z "$PI_HOST" ]]; then
+  echo "Error: --pi-host is required"
+  usage
+fi
+
+if [[ -z "$THING_NAME" ]]; then
+  read -p "Enter a name for your IoT Thing: " THING_NAME
+  if [[ -z "$THING_NAME" ]]; then
+    echo "Error: Thing name cannot be empty"
+    exit 1
+  fi
+fi
+
+# Resolve region: explicit flag > profile config > fallback
+if [[ -z "$AWS_REGION" ]]; then
+  AWS_REGION=$(aws configure get region --profile "${AWS_PROFILE}" 2>/dev/null || echo "us-east-1")
+fi
+
+AWS_CMD="aws --profile ${AWS_PROFILE} --region ${AWS_REGION}"
+
+# Verify AWS session is active
+echo "=== Verifying AWS credentials ==="
+if ! ${AWS_CMD} sts get-caller-identity &>/dev/null; then
+  echo "AWS session is not active. Logging in..."
+  aws sso login --profile "${AWS_PROFILE}"
+fi
+CALLER_IDENTITY=$(${AWS_CMD} sts get-caller-identity)
+echo "Authenticated as: $(echo "$CALLER_IDENTITY" | jq -r '.Arn')"
+echo ""
+
+# Verify SSH connectivity to Pi and resolve remote home directory
+echo "=== Verifying SSH connectivity to ${PI_HOST} ==="
+PI_HOME=$(ssh -o ConnectTimeout=5 -o BatchMode=yes "${PI_HOST}" 'echo $HOME' 2>/dev/null) || {
+  echo "Error: Cannot SSH to ${PI_HOST}. Check your SSH keys and network."
+  exit 1
+}
+PI_WORK_DIR="${PI_HOME}/kvs-webrtc-setup"
+echo "SSH connection verified. Remote home: ${PI_HOME}"
+echo ""
+
+# ─── Local staging directory ─────────────────────────────────────────────────
+
+STAGING_DIR=$(mktemp -d)
+IOT_DIR="${STAGING_DIR}/iot"
+CERTS_DIR="${IOT_DIR}/certs"
+CMD_RESULTS_DIR="${IOT_DIR}/cmd-responses"
+
+mkdir -p "${CERTS_DIR}" "${CMD_RESULTS_DIR}"
+
+cleanup() {
+  echo "Cleaning up staging directory..."
+  rm -rf "${STAGING_DIR}"
+}
+trap cleanup EXIT
+
+# ─── IoT Provisioning (runs locally with AWS credentials) ────────────────────
+
+THING_TYPE=kvs_example_camera
+IAM_ROLE=KVSCameraCertificateBasedIAMRole
+IAM_POLICY=KVSCameraIAMPolicy
+IOT_ROLE_ALIAS=KvsCameraIoTRoleAlias
+IOT_POLICY=KvsCameraIoTPolicy
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=== Provisioning AWS IoT resources ==="
+echo "  Thing Name : ${THING_NAME}"
+echo "  Thing Type : ${THING_TYPE}"
+echo "  Region     : ${AWS_REGION}"
+echo ""
+
+# Save thing metadata
+echo "${THING_NAME}" > "${IOT_DIR}/thing-name"
+echo "${IOT_ROLE_ALIAS}" > "${IOT_DIR}/role-alias"
+
+# Create Thing Type
+if ${AWS_CMD} iot describe-thing-type --thing-type-name "${THING_TYPE}" &>/dev/null; then
+  echo "Thing type '${THING_TYPE}' already exists."
+else
+  echo "Creating thing type '${THING_TYPE}'..."
+  ${AWS_CMD} iot create-thing-type --thing-type-name "${THING_TYPE}"
+fi
+
+# Create Thing
+if ${AWS_CMD} iot describe-thing --thing-name "${THING_NAME}" &>/dev/null; then
+  echo "Thing '${THING_NAME}' already exists."
+else
+  echo "Creating thing '${THING_NAME}'..."
+  ${AWS_CMD} iot create-thing --thing-name "${THING_NAME}" --thing-type-name "${THING_TYPE}"
+fi
+
+# Create IAM Role
+if ${AWS_CMD} iam get-role --role-name "${IAM_ROLE}" &>/dev/null; then
+  echo "IAM role '${IAM_ROLE}' already exists."
+  ${AWS_CMD} iam get-role --role-name "${IAM_ROLE}" > "${CMD_RESULTS_DIR}/iam-role.json"
+else
+  echo "Creating IAM role '${IAM_ROLE}'..."
+  ${AWS_CMD} iam create-role --role-name "${IAM_ROLE}" \
+    --assume-role-policy-document "file://${SCRIPT_DIR}/iot/iam-policy-document.json" \
+    > "${CMD_RESULTS_DIR}/iam-role.json"
+fi
+
+# Attach IAM Role Policy
+if ${AWS_CMD} iam get-role-policy --role-name "${IAM_ROLE}" --policy-name "${IAM_POLICY}" &>/dev/null; then
+  echo "IAM role policy '${IAM_POLICY}' already exists."
+else
+  echo "Attaching IAM role policy '${IAM_POLICY}'..."
+  ${AWS_CMD} iam put-role-policy --role-name "${IAM_ROLE}" \
+    --policy-name "${IAM_POLICY}" \
+    --policy-document "file://${SCRIPT_DIR}/iot/iam-permission-document.json"
+fi
+
+# Create IoT Role Alias
+if ${AWS_CMD} iot describe-role-alias --role-alias "${IOT_ROLE_ALIAS}" &>/dev/null; then
+  echo "IoT role alias '${IOT_ROLE_ALIAS}' already exists."
+  ${AWS_CMD} iot describe-role-alias --role-alias "${IOT_ROLE_ALIAS}" \
+    > "${CMD_RESULTS_DIR}/iot-role-alias.json"
+else
+  echo "Creating IoT role alias '${IOT_ROLE_ALIAS}'..."
+  ROLE_ARN=$(jq -r '.Role.Arn' "${CMD_RESULTS_DIR}/iam-role.json")
+  ${AWS_CMD} iot create-role-alias --role-alias "${IOT_ROLE_ALIAS}" \
+    --role-arn "${ROLE_ARN}" \
+    --credential-duration-seconds 3600 \
+    > "${CMD_RESULTS_DIR}/iot-role-alias.json"
+fi
+
+# Create IoT Policy
+if ${AWS_CMD} iot get-policy --policy-name "${IOT_POLICY}" &>/dev/null; then
+  echo "IoT policy '${IOT_POLICY}' already exists."
+else
+  echo "Creating IoT policy '${IOT_POLICY}'..."
+  ROLE_ALIAS_ARN=$(jq -r '.roleAliasDescription.roleAliasArn' "${CMD_RESULTS_DIR}/iot-role-alias.json")
+
+  cat > "${STAGING_DIR}/iot-policy-document.json" <<POLICYEOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["iot:Connect"],
+      "Resource": "${ROLE_ALIAS_ARN}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["iot:AssumeRoleWithCertificate"],
+      "Resource": "${ROLE_ALIAS_ARN}"
+    }
+  ]
+}
+POLICYEOF
+
+  ${AWS_CMD} iot create-policy --policy-name "${IOT_POLICY}" \
+    --policy-document "file://${STAGING_DIR}/iot-policy-document.json"
+fi
+
+# Create device certificate and keys
+if [[ ! -f "${CERTS_DIR}/device.cert.pem" ]]; then
+  echo "Creating device certificate and keys..."
+  ${AWS_CMD} iot create-keys-and-certificate --set-as-active \
+    --certificate-pem-outfile "${CERTS_DIR}/device.cert.pem" \
+    --public-key-outfile "${CERTS_DIR}/device.public.key" \
+    --private-key-outfile "${CERTS_DIR}/device.private.key" \
+    > "${CMD_RESULTS_DIR}/keys-and-certificate.json"
+
+  CERT_ARN=$(jq -r '.certificateArn' "${CMD_RESULTS_DIR}/keys-and-certificate.json")
+
+  echo "Attaching IoT policy to certificate..."
+  ${AWS_CMD} iot attach-policy --policy-name "${IOT_POLICY}" --target "${CERT_ARN}"
+
+  echo "Attaching thing principal..."
+  ${AWS_CMD} iot attach-thing-principal --thing-name "${THING_NAME}" --principal "${CERT_ARN}"
+else
+  echo "Device certificate already exists in staging directory."
+fi
+
+# Download root CA
+if [[ ! -f "${CERTS_DIR}/root-CA.crt" ]]; then
+  echo "Downloading Amazon root CA certificate..."
+  curl --silent 'https://www.amazontrust.com/repository/SFSRootCAG2.pem' \
+    --output "${CERTS_DIR}/root-CA.crt"
+fi
+
+# Get credential provider endpoint
+echo "Fetching IoT credential provider endpoint..."
+CREDENTIAL_ENDPOINT=$(${AWS_CMD} iot describe-endpoint --endpoint-type iot:CredentialProvider --output text)
+echo "${CREDENTIAL_ENDPOINT}" > "${IOT_DIR}/credential-provider-endpoint"
+
+echo ""
+echo "=== AWS IoT provisioning complete ==="
+echo "  Thing Name              : ${THING_NAME}"
+echo "  Credential Endpoint     : ${CREDENTIAL_ENDPOINT}"
+echo "  Certificates staged in  : ${CERTS_DIR}"
+echo ""
+
+# ─── Generate the run script ─────────────────────────────────────────────────
+
+echo "=== Generating run script ==="
+
+cat > "${STAGING_DIR}/run-kvs-webrtc-client-master-sample.sh" <<RUNEOF
+#!/bin/bash
+KVS_SDK_HOME=${KVS_INSTALL_DIR}
+
+export AWS_DEFAULT_REGION=${AWS_REGION}
+export AWS_IOT_CORE_CREDENTIAL_ENDPOINT=${CREDENTIAL_ENDPOINT}
+export AWS_IOT_CORE_ROLE_ALIAS=${IOT_ROLE_ALIAS}
+export AWS_IOT_CORE_THING_NAME=${THING_NAME}
+
+export AWS_IOT_CORE_CERT=\${KVS_SDK_HOME}/iot/certs/device.cert.pem
+export AWS_IOT_CORE_PRIVATE_KEY=\${KVS_SDK_HOME}/iot/certs/device.private.key
+export IOT_CA_CERT_PATH=\${KVS_SDK_HOME}/iot/certs/root-CA.crt
+export AWS_KVS_CACERT_PATH=\${KVS_SDK_HOME}/certs/cert.pem
+
+export DEBUG_LOG_SDP=TRUE
+export AWS_KVS_LOG_LEVEL=1
+export AWS_ENABLE_FILE_LOGGING=TRUE
+
+# GStreamer pipeline for video-only streaming (libcamerasrc for Raspberry Pi cameras).
+# Edit this to change resolution, framerate, encoder settings, etc. without recompiling.
+# The pipeline MUST end with: appsink sync=TRUE emit-signals=TRUE name=appsink-video
+export KVS_GST_VIDEO_PIPELINE="libcamerasrc ! video/x-raw,width=1280,height=720,framerate=30/1 ! queue ! videoconvert ! video/x-raw,format=I420 ! x264enc bframes=0 speed-preset=veryfast bitrate=512 byte-stream=TRUE tune=zerolatency key-int-max=30 ! video/x-h264,stream-format=byte-stream,alignment=au ! appsink sync=TRUE emit-signals=TRUE name=appsink-video"
+
+\${KVS_SDK_HOME}/build/samples/kvsWebrtcClientMasterGstSample ${THING_NAME}
+RUNEOF
+
+chmod 755 "${STAGING_DIR}/run-kvs-webrtc-client-master-sample.sh"
+
+# ─── Deploy to Raspberry Pi ──────────────────────────────────────────────────
+
+echo "=== Deploying to Raspberry Pi (${PI_HOST}) ==="
+
+# Create working directory on Pi
+ssh "${PI_HOST}" "mkdir -p ${PI_WORK_DIR}"
+
+# Copy IoT certs and config to Pi
+echo "Copying IoT certificates and config..."
+scp -r "${IOT_DIR}" "${PI_HOST}:${PI_WORK_DIR}/iot"
+
+# Copy the run script
+echo "Copying run script..."
+scp "${STAGING_DIR}/run-kvs-webrtc-client-master-sample.sh" "${PI_HOST}:${PI_WORK_DIR}/"
+
+# Copy the setup script, patch script, and service file to Pi
+echo "Copying setup script and service file..."
+scp "${SCRIPT_DIR}/setup-pi.sh" "${PI_HOST}:${PI_WORK_DIR}/"
+scp "${SCRIPT_DIR}/patch-gst-pipeline.sh" "${PI_HOST}:${PI_WORK_DIR}/"
+scp "${SCRIPT_DIR}/kvs-webrtc.service" "${PI_HOST}:${PI_WORK_DIR}/"
+
+echo ""
+echo "=== Running remote setup on Raspberry Pi ==="
+echo "This will install dependencies and build the SDK. This may take a while..."
+echo ""
+
+# Run the setup script on the Pi
+ssh -t "${PI_HOST}" "chmod +x ${PI_WORK_DIR}/setup-pi.sh && ${PI_WORK_DIR}/setup-pi.sh"
+
+echo ""
+echo "=========================================="
+echo "  Setup complete!"
+echo "=========================================="
+echo ""
+echo "Your Raspberry Pi is now configured as IoT Thing '${THING_NAME}'."
+echo ""
+echo "Check the service status:"
+echo "  ssh ${PI_HOST} 'sudo systemctl status kvs-webrtc.service'"
+echo ""
+echo "View logs:"
+echo "  ssh ${PI_HOST} 'tail -f /var/log/kvs-webrtc.log'"
+echo ""
+echo "Test your camera at:"
+echo "  https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html"
+echo ""

--- a/setup-aws-sso.sh
+++ b/setup-aws-sso.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# setup-aws-sso.sh
+#
+# Configures an AWS SSO profile for use with the KVS WebRTC provisioning scripts.
+# This only needs to be run once. After that, use `aws sso login --profile <name>`
+# to refresh your session.
+#
+# Usage:
+#   ./setup-aws-sso.sh [PROFILE_NAME]
+#
+# Example:
+#   ./setup-aws-sso.sh work
+#
+
+set -euo pipefail
+
+# ─── Prerequisites check ─────────────────────────────────────────────────────
+
+if ! command -v aws &>/dev/null; then
+  echo "Error: AWS CLI is not installed."
+  echo "Install it from: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+  exit 1
+fi
+
+AWS_CLI_MAJOR=$(aws --version 2>&1 | grep -oE 'aws-cli/[0-9]+' | cut -d/ -f2)
+if [[ "${AWS_CLI_MAJOR}" -lt 2 ]]; then
+  echo "Error: AWS CLI v2 is required for SSO support (found v${AWS_CLI_MAJOR})."
+  echo "Install it from: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+  exit 1
+fi
+
+PROFILE_NAME="${1:-}"
+
+if [[ -z "$PROFILE_NAME" ]]; then
+  read -p "Enter a name for your AWS CLI profile (e.g. work, personal): " PROFILE_NAME
+  if [[ -z "$PROFILE_NAME" ]]; then
+    echo "Error: Profile name cannot be empty."
+    exit 1
+  fi
+fi
+
+echo "=== AWS SSO Profile Setup ==="
+echo ""
+echo "This will walk you through configuring an AWS SSO profile named '${PROFILE_NAME}'."
+echo "You will need your IAM Identity Center start URL, account ID, and role name."
+echo ""
+
+# Check if profile already exists
+if aws configure get sso_start_url --profile "${PROFILE_NAME}" &>/dev/null; then
+  echo "Profile '${PROFILE_NAME}' already exists in ~/.aws/config."
+  echo ""
+  read -p "Overwrite it? [y/N] " -n 1 -r
+  echo ""
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Keeping existing profile. Run 'aws sso login --profile ${PROFILE_NAME}' to log in."
+    exit 0
+  fi
+fi
+
+# aws configure sso walks through the full setup interactively
+aws configure sso --profile "${PROFILE_NAME}"
+
+echo ""
+echo "=== SSO profile '${PROFILE_NAME}' configured ==="
+echo ""
+echo "To log in:  aws sso login --profile ${PROFILE_NAME}"
+echo "To verify:  aws sts get-caller-identity --profile ${PROFILE_NAME}"
+echo ""
+echo "Then run the provisioning script:"
+echo "  ./provision-local.sh --profile ${PROFILE_NAME} --pi-host <user>@<pi-ip> --thing-name <name>"

--- a/setup-pi.sh
+++ b/setup-pi.sh
@@ -1,0 +1,223 @@
+#!/bin/bash
+#
+# setup-pi.sh
+#
+# Runs ON the Raspberry Pi (invoked via SSH from provision-local.sh).
+# Installs system dependencies, clones and builds the KVS WebRTC SDK,
+# and installs the systemd service.
+#
+# Uses BUILD_DEPENDENCIES=OFF to speed up compilation by relying on
+# system packages for libsrtp and libusrsctp. libwebsockets is built
+# from source because the SDK requires v4.3.5 and Bookworm ships 4.1.6.
+#
+
+set -euo pipefail
+
+WORK_DIR="${HOME}/kvs-webrtc-setup"
+KVS_INSTALL_DIR="/opt/amazon-kinesis-video-streams-webrtc-sdk-c"
+SDK_REPO="https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c"
+LWS_VERSION="v4.3.5"
+
+echo "=== Raspberry Pi Setup ==="
+echo ""
+
+# ─── Install system dependencies ─────────────────────────────────────────────
+
+echo "=== Installing system packages ==="
+sudo apt-get update -qq
+sudo apt-get install -y \
+  git \
+  cmake \
+  pkg-config \
+  libssl-dev \
+  libmbedtls-dev \
+  libcurl4-openssl-dev \
+  liblog4cplus-dev \
+  libsrtp2-dev \
+  libusrsctp-dev \
+  libgstreamer1.0-dev \
+  libgstreamer-plugins-base1.0-dev \
+  gstreamer1.0-plugins-base-apps \
+  gstreamer1.0-plugins-bad \
+  gstreamer1.0-plugins-good \
+  gstreamer1.0-plugins-ugly \
+  gstreamer1.0-tools \
+  gstreamer1.0-libcamera
+
+echo ""
+
+# ─── Validate camera hardware ────────────────────────────────────────────────
+# Catch common configuration issues before spending time on the build.
+
+echo "=== Checking camera configuration ==="
+
+# Check that camera_auto_detect or a camera dtoverlay is enabled in boot config
+BOOT_CONFIG=""
+for f in /boot/firmware/config.txt /boot/config.txt; do
+  if [[ -f "$f" ]]; then
+    BOOT_CONFIG="$f"
+    break
+  fi
+done
+
+if [[ -n "${BOOT_CONFIG}" ]]; then
+  if ! grep -qE '^camera_auto_detect=1|^dtoverlay=imx|^dtoverlay=ov' "${BOOT_CONFIG}" 2>/dev/null; then
+    echo "WARNING: No camera configuration found in ${BOOT_CONFIG}."
+    echo "  Ensure 'camera_auto_detect=1' is set, or add the appropriate"
+    echo "  dtoverlay for your camera module (e.g. dtoverlay=imx219)."
+    echo "  Then reboot before running this script again."
+    echo ""
+    read -p "Continue anyway? [y/N] " -n 1 -r
+    echo ""
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+      exit 1
+    fi
+  fi
+else
+  echo "WARNING: Could not find boot config file. Skipping camera config check."
+fi
+
+# Check that a camera is actually detected by libcamera
+CAMERA_COUNT=0
+if command -v rpicam-hello &>/dev/null; then
+  CAMERA_COUNT=$(rpicam-hello --list-cameras 2>&1 | grep -cE '^[0-9]+ :' || true)
+elif command -v libcamera-hello &>/dev/null; then
+  CAMERA_COUNT=$(libcamera-hello --list-cameras 2>&1 | grep -cE '^[0-9]+ :' || true)
+fi
+
+if [[ "${CAMERA_COUNT}" -eq 0 ]]; then
+  echo ""
+  echo "ERROR: No camera detected by libcamera."
+  echo ""
+  echo "Troubleshooting steps:"
+  echo "  1. Verify the camera ribbon cable is firmly seated at both ends"
+  echo "  2. Ensure the cable is oriented correctly (contacts facing the board)"
+  echo "  3. Check that your boot config (${BOOT_CONFIG:-/boot/firmware/config.txt})"
+  echo "     contains 'camera_auto_detect=1'"
+  echo "  4. Reboot after making any changes: sudo reboot"
+  echo "  5. Test with: rpicam-hello --list-cameras"
+  echo ""
+  read -p "Continue without a detected camera? [y/N] " -n 1 -r
+  echo ""
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 1
+  fi
+else
+  echo "Camera detected (${CAMERA_COUNT} camera(s) found)."
+fi
+
+# Check that the libcamera GStreamer plugin is functional
+if ! gst-inspect-1.0 libcamerasrc &>/dev/null; then
+  echo "WARNING: GStreamer libcamerasrc plugin not found."
+  echo "  The gstreamer1.0-libcamera package may not have installed correctly."
+  echo "  The SDK will not be able to capture video from the camera."
+fi
+
+echo ""
+
+# ─── Build libwebsockets from source ─────────────────────────────────────────
+# The SDK requires libwebsockets v4.3.5 but Bookworm only ships 4.1.6.
+# Build it once and install to /usr/local so the SDK can find it.
+
+LWS_MARKER="/usr/local/lib/pkgconfig/libwebsockets.pc"
+if [[ -f "${LWS_MARKER}" ]] && pkg-config --atleast-version=4.3.5 libwebsockets 2>/dev/null; then
+  echo "=== libwebsockets >= 4.3.5 already installed, skipping ==="
+else
+  echo "=== Building libwebsockets ${LWS_VERSION} from source ==="
+  LWS_SRC_DIR="${WORK_DIR}/libwebsockets"
+
+  if [[ ! -d "${LWS_SRC_DIR}" ]]; then
+    git clone --branch "${LWS_VERSION}" --depth 1 \
+      https://github.com/warmcat/libwebsockets.git "${LWS_SRC_DIR}"
+  fi
+
+  mkdir -p "${LWS_SRC_DIR}/build"
+  cd "${LWS_SRC_DIR}/build"
+  cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLWS_WITH_STATIC=ON \
+    -DLWS_WITH_SHARED=ON \
+    -DLWS_WITHOUT_TESTAPPS=ON \
+    -DLWS_WITHOUT_TEST_SERVER=ON \
+    -DLWS_WITHOUT_TEST_PING=ON \
+    -DLWS_WITHOUT_TEST_CLIENT=ON
+  make -j$(nproc)
+  sudo make install
+  sudo ldconfig
+  cd "${WORK_DIR}"
+
+  echo "libwebsockets ${LWS_VERSION} installed to /usr/local"
+fi
+
+echo ""
+
+# ─── Clone and build the SDK ─────────────────────────────────────────────────
+
+SDK_SRC_DIR="${WORK_DIR}/amazon-kinesis-video-streams-webrtc-sdk-c"
+
+if [[ ! -d "${SDK_SRC_DIR}" ]]; then
+  echo "=== Cloning KVS WebRTC SDK ==="
+  git clone "${SDK_REPO}" "${SDK_SRC_DIR}"
+else
+  echo "=== SDK source already present, pulling latest ==="
+  cd "${SDK_SRC_DIR}"
+  git pull
+  cd "${WORK_DIR}"
+fi
+
+echo "=== Patching SDK for configurable GStreamer pipeline ==="
+# Raspberry Pi OS Bookworm uses libcamera instead of the legacy camera stack.
+# Instead of hardcoding a pipeline, patch the SDK to read from environment
+# variables (KVS_GST_VIDEO_PIPELINE / KVS_GST_AUDIO_VIDEO_PIPELINE) so the
+# pipeline can be tuned without recompiling.
+GSTMEDIA="${SDK_SRC_DIR}/samples/common/GstMedia.c"
+if [[ -f "${GSTMEDIA}" ]]; then
+  bash "${WORK_DIR}/patch-gst-pipeline.sh" "${GSTMEDIA}"
+else
+  echo "WARNING: GstMedia.c not found at expected path, skipping pipeline patch"
+fi
+
+echo "=== Building SDK with BUILD_DEPENDENCIES=OFF ==="
+mkdir -p "${SDK_SRC_DIR}/build"
+cd "${SDK_SRC_DIR}/build"
+cmake .. \
+  -DBUILD_DEPENDENCIES=OFF \
+  -DIOT_CORE_ENABLE_CREDENTIALS=ON \
+  -DCMAKE_PREFIX_PATH=/usr/local
+make -j$(nproc)
+cd "${WORK_DIR}"
+
+echo ""
+
+# ─── Install to /opt/ ────────────────────────────────────────────────────────
+
+echo "=== Installing to ${KVS_INSTALL_DIR} ==="
+sudo mkdir -p "${KVS_INSTALL_DIR}"
+
+# Copy the built SDK
+sudo cp -r "${SDK_SRC_DIR}/build" "${KVS_INSTALL_DIR}/"
+sudo cp -r "${SDK_SRC_DIR}/certs" "${KVS_INSTALL_DIR}/" 2>/dev/null || true
+
+# Copy IoT certs and config (placed here by provision-local.sh via SCP)
+sudo cp -r "${WORK_DIR}/iot" "${KVS_INSTALL_DIR}/"
+sudo chmod -R +r "${KVS_INSTALL_DIR}/iot/"
+
+# Copy the run script
+sudo cp "${WORK_DIR}/run-kvs-webrtc-client-master-sample.sh" "${KVS_INSTALL_DIR}/"
+sudo chmod 755 "${KVS_INSTALL_DIR}/run-kvs-webrtc-client-master-sample.sh"
+
+echo ""
+
+# ─── Install systemd service ─────────────────────────────────────────────────
+
+echo "=== Installing systemd service ==="
+sudo cp "${WORK_DIR}/kvs-webrtc.service" /etc/systemd/system/kvs-webrtc.service
+sudo systemctl daemon-reload
+sudo systemctl enable kvs-webrtc.service
+sudo systemctl start kvs-webrtc.service
+
+echo ""
+echo "=== Raspberry Pi setup complete ==="
+echo ""
+echo "Service status:"
+sudo systemctl status kvs-webrtc.service --no-pager || true


### PR DESCRIPTION
- Add provision-local.sh: orchestrates AWS IoT provisioning from a local machine, then deploys certs and build scripts to a Pi via SSH
- Add setup-aws-sso.sh: helper to configure an AWS SSO CLI profile
- Add setup-pi.sh: runs on the Pi to install deps, build libwebsockets v4.3.5 from source, and compile the SDK with BUILD_DEPENDENCIES=OFF
- Add iot/provisioning-iam-policy.json: minimal IAM policy for provisioning (no admin access required)
- Update build-kvs-webrtc.sh: use BUILD_DEPENDENCIES=OFF, build libwebsockets from source, handle relocated Samples.h in newer SDK
- Update README.md: document both workflows, prerequisites, minimum IAM permissions, and Pi setup requirements